### PR TITLE
fix undefined references

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 LIBS=xft xcb xcb-atom xcb-keysyms xcb-composite xcb-damage xcb-xinerama \
-     xcb-xfixes xcb-randr x11 x11-xcb xrender gl xcb-ewmh xcb-icccm xcb-image
+     xcb-xfixes xcb-randr x11 x11-xcb xrender gl xcb-ewmh xcb-icccm xcb-image xcb-render
 CXXFLAGS=-g -std=c++11 -Wall -O3 $(shell pkg-config --cflags ${LIBS})
 LDFLAGS=$(shell pkg-config --libs ${LIBS})
 


### PR DESCRIPTION
When building, i get numerous undefined references.

Don't know, does anyone have working it, as i get X BadAlloc error, which might be due to intel video driver bug (glxinfo showes opengl version 3.0).